### PR TITLE
Update sync/device.c

### DIFF
--- a/sync/device.c
+++ b/sync/device.c
@@ -150,7 +150,7 @@ static int get_track_data(struct sync_device *d, struct sync_track *t)
 	for (i = 0; i < (int)t->num_keys; ++i) {
 		struct track_key *key = t->keys + i;
 		char type;
-		d->io_cb.read(&key->row, sizeof(size_t), 1, fp);
+		d->io_cb.read(&key->row, sizeof(int), 1, fp);
 		d->io_cb.read(&key->value, sizeof(float), 1, fp);
 		d->io_cb.read(&type, sizeof(char), 1, fp);
 		key->type = (enum key_type)type;


### PR DESCRIPTION
size_t is not necessarily an int (on OSX it isn't), so reading back sizeof(size_t) as opposed to sizeof(int) won't work. I take it it's a copy/paste bug :)
