### PR TITLE
Fix socket to wait for data after WebSocket upgrade

### DIFF
--- a/editor/mainwindow.cpp
+++ b/editor/mainwindow.cpp
@@ -467,6 +467,7 @@ static TcpSocket *clientConnect(QTcpServer *serverSocket, QHostAddress *host)
 	if (!line.compare(0, 4, "GET ")) {
 		ret = WebSocket::upgradeFromHttp(clientSocket);
 		line.resize(strlen(expectedGreeting));
+		clientSocket->waitForReadyRead();
 		if (!ret || !ret->recv(&line[0], line.length())) {
 			clientSocket->close();
 			return NULL;


### PR DESCRIPTION
Hi!

I just tried to integrate Rocket to my Stream 10 demo, but I had a problem with WebSocket connection; it closed instantly before a valid connection to editor was even established. I tracked this down to greet-reading code that is executed after WebSocket upgrade. Editor didn't wait for data, but instead tried to immediately read the socket, which caused it to close abruptly. The line added in this PR should fix the issue.
