### PR TITLE
Problems with TCP packets

### DIFF
--- a/editor/mainwindow.cpp
+++ b/editor/mainwindow.cpp
@@ -448,13 +448,19 @@ static TcpSocket *clientConnect(QTcpServer *serverSocket, QHostAddress *host)
 
 	const char *expectedGreeting = CLIENT_GREET;
 	std::string line;
-
 	line.resize(0);
+
+	// Read greetings or WebSocket upgrade
+	// command from the socket
 	for (;;) {
 		char ch;
 		if (!clientSocket->getChar(&ch)) {
-			clientSocket->close();
-			return NULL;
+			// Read failed; wait for data and try again
+			clientSocket->waitForReadyRead();
+			if(!clientSocket->getChar(&ch)) {
+				clientSocket->close();
+				return NULL;
+			}
 		}
 
 		if (ch == '\n')


### PR DESCRIPTION
Hi kusma!

I'm developing a Rocket integration library for Processing. In the process I've encountered some problems with how Rocket handles communication over TCP. 

As far as I've understood, the main problem is that Rocket assumes that full data is always readable from the socket.  It checks that there is some data available before trying to read from it (`pollRead` checks that `>0` bytes are available), but it doesn't check that **all** data for some command is available. If a command packet arrives only partially, `TcpSocket::recv` closes the socket and connection is lost.

I'm happy to craft a patch for this, but what do you think would be the best way forward? Peeking to socket and reading from it only when command data is fully available or converting `TcpSocket::recv` so that it blocks until all requested bytes have been read? 
