### PR TITLE
travis: fixup paths to frameworks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ os:
 before_script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       brew update &&
+      brew install coreutils &&
       brew install qt5 &&
       brew install sdl &&
       export QT5_PREFIX="`brew --prefix qt5`";
@@ -54,6 +55,20 @@ before_deploy:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       (cd editor &&
       "$QT5_PREFIX/bin/macdeployqt" editor.app &&
+      prefix="`grealpath $QT5_PREFIX`";
+      frameworks=(editor.app/Contents/Frameworks/Qt*.framework) &&
+      frameworks=("${frameworks[@]#editor.app/Contents/Frameworks/}") &&
+      frameworks=("${frameworks[@]%.framework}") &&
+      for framework in "${frameworks[@]}"; do
+        for target in "${frameworks[@]}"; do
+          install_name_tool -change $prefix/lib/$target.framework/Versions/5/$target @executable_path/../Frameworks/$target.framework/Versions/5/$target editor.app/Contents/Frameworks/$framework.framework/$framework;
+        done;
+      done;
+      for plugin in editor.app/Contents/PlugIns/*/*.dylib; do
+        for target in "${frameworks[@]}"; do
+          install_name_tool -change $prefix/lib/$target.framework/Versions/5/$target @executable_path/../Frameworks/$target.framework/Versions/5/$target $plugin;
+        done;
+      done;
       zip -r rocket-editor-$VERSION_TAG-$TRAVIS_OS_NAME.zip editor.app)
     fi
 


### PR DESCRIPTION
Seems macdeployqt is highly flawed in the qt5 brew-package, and
doesn't do everything we need. In particular, the frame-references
inside the Qt libraries themselves are not relative to the
application itself. So let's just roll up our sleeves and do it
ourselves.