### PR TITLE
editor: use QSaveFile if available

### DIFF
--- a/editor/syncdocument.cpp
+++ b/editor/syncdocument.cpp
@@ -4,6 +4,10 @@
 #include <QDomDocument>
 #include <QTextStream>
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 1, 0))
+#include <QSaveFile>
+#define USE_QSAVEFILE
+#endif
 
 SyncDocument::~SyncDocument()
 {
@@ -178,7 +182,12 @@ bool SyncDocument::save(const QString &fileName)
 	rootNode.appendChild(bookmarksNode);
 	rootNode.appendChild(doc.createTextNode("\n"));
 
+#ifdef USE_QSAVEFILE
+	QSaveFile file(fileName);
+#else
 	QFile file(fileName);
+#endif
+
 	if (!file.open(QIODevice::WriteOnly | QIODevice::Text)) {
 		QMessageBox::critical(NULL, "Error", file.errorString());
 		return false;
@@ -187,7 +196,12 @@ bool SyncDocument::save(const QString &fileName)
 	streamFileOut.setCodec("UTF-8");
 	streamFileOut << doc.toString();
 	streamFileOut.flush();
+
+#ifdef USE_QSAVEFILE
+	file.commit();
+#else
 	file.close();
+#endif
 
 	undoStack.setClean();
 	return true;


### PR DESCRIPTION
In the unlikely event of a power-outage or similar sudden
interruption while the document is writing to disk, it's better to
save to a temp-file and atomically rename that file to the new one
instead of leaving a half-written file on disk.

However, this has several subtleties to it that I don't really want
to have to deal with myself, so let's just use the Qt 5.1 QSaveFile
API for this. This means that older Qt versions will have to live
with the slightly less robust solution for now.