### PR TITLE
editor: fix crash in debug-build

### DIFF
--- a/editor/trackview.cpp
+++ b/editor/trackview.cpp
@@ -409,7 +409,7 @@ void TrackView::editCopy()
 	data.append((char *)&buffer_width, sizeof(int));
 	data.append((char *)&buffer_height, sizeof(int));
 	data.append((char *)&buffer_size, sizeof(size_t));
-	data.append((char *)&copyEntries[0], sizeof(CopyEntry) * copyEntries.size());
+	data.append((char *)copyEntries.data(), sizeof(CopyEntry) * copyEntries.size());
 
 	QMimeData *mimeData = new QMimeData;
 	mimeData->setData("application/x-gnu-rocket", data);


### PR DESCRIPTION
Taking the address of the first element is invalid when the QVector
is empty, and Qt will trigger an assertion on this in debug-builds.

Luckily, it's completely benign in release-builds, which is what
most people use. But let's make sure we don't annoy those users who
do trigger this, by discarding all their changes!