### PR TITLE
editor: invalidate deleted keyframe

### DIFF
--- a/editor/syncpage.cpp
+++ b/editor/syncpage.cpp
@@ -114,5 +114,6 @@ void SyncPage::onKeyFrameRemoved(int row, const SyncTrack::TrackKey &oldKey)
 	if (oldKey.type != startKey->type) {
 		int endRow = endKey != NULL ? endKey->row - 1 : document->getRows();
 		invalidateTrackData(*track, startKey->row, endRow);
-	}
+	} else
+		invalidateTrackData(*track, row, row);
 }


### PR DESCRIPTION
This was a silly slip-up; we definately need to invalidate the key
that was deleted, no matter what the interpolation mode was.