### PR TITLE
travis: do not install coreutils

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ os:
 before_script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       brew update &&
-      brew install coreutils &&
       brew install qt5 &&
       brew install sdl &&
       export QT5_PREFIX="`brew --prefix qt5`";


### PR DESCRIPTION
It seems Travis now already have coreutils installed on their osx
builders. And since brew doesn't seem to have an easy-to-use flag
to skip installing installed packages, and instead spews an error,
let's just drop installing the package in the first place.