### PR TITLE
README: change around the license-badge a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Rocket
 [![Build status](https://ci.appveyor.com/api/projects/status/dfq8qaedc6mtsefg/branch/master?svg=true)](https://ci.appveyor.com/project/kusma/rocket/branch/master)
 [![Build status](https://travis-ci.org/rocket/rocket.svg?branch=master)](https://travis-ci.org/rocket/rocket)
 [![Gitter](https://badges.gitter.im/rocket/rocket.svg)](https://gitter.im/rocket/rocket?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
-[![License: Zlib](https://img.shields.io/badge/License-Zlib-blue.svg)](https://opensource.org/licenses/Zlib)
+[![license: Zlib](https://img.shields.io/github/license/rocket/rocket.svg)](https://github.com/kusma/rocket/blob/master/LICENSE.txt)
 
 Rocket is an intuitive new way of... bah, whatever. It's a sync-tracker, a
 tool for synchronizing music and visuals in demoscene productions. It


### PR DESCRIPTION
Let's point at our own license-file rather than the copy at
opensource.org.

While we're at it, let's have shields.io pick the license from the github
API, instead of specifying. This means there's less things that needs to
be changed if we ever decided to relicence. Not that there's any plans for
that.