### PR TITLE
editor: update other track-pages when navigating

### DIFF
--- a/editor/mainwindow.cpp
+++ b/editor/mainwindow.cpp
@@ -497,6 +497,11 @@ void MainWindow::onEditRowChanged(int row)
 {
 	if (syncClient)
 		syncClient->sendSetRowCommand(row);
+
+	for (int i = 0; i < trackViews.size(); ++i) {
+		if (trackViews[i] != QObject::sender())
+			trackViews[i]->updateRow(row);
+	}
 }
 
 void MainWindow::onCurrValDirty()


### PR DESCRIPTION
In 435c884 ("editor: allow navigation while playing"), I forgot that
other pages needs the same update as well. So let's just pipe that
through.

We can safely do it here, because this setter is treated as a
non-navigation row-change, which means that it will not emit an
editRowChanged(int) signal in response.