### PR TITLE
editor: kill dead code

### DIFF
--- a/editor/mainwindow.cpp
+++ b/editor/mainwindow.cpp
@@ -573,10 +573,6 @@ void MainWindow::onSyncPageAdded(SyncPage *page)
 
 void MainWindow::onTabChanged(int index)
 {
-	int row = 0;
-	if (currentTrackView)
-		row = currentTrackView->getEditRow();
-
 	setTrackView(index < 0 ? NULL : trackViews[index]);
 
 	if (currentTrackView)


### PR DESCRIPTION
In the recent row-setting refactorings, it seems this code got
left over. It even produces a warning for me, so let's terminate
it.