### PR TITLE
Allow non-portable path/file characters

### DIFF
--- a/lib/device.c
+++ b/lib/device.c
@@ -174,7 +174,7 @@ static SOCKET server_connect(const char *host, unsigned short nport)
 			char greet[128];
 
 			if (xsend(sock, CLIENT_GREET, strlen(CLIENT_GREET), 0) ||
-				xrecv(sock, greet, strlen(SERVER_GREET), 0)) {
+			    xrecv(sock, greet, strlen(SERVER_GREET), 0)) {
 				closesocket(sock);
 				sock = INVALID_SOCKET;
 				continue;
@@ -195,7 +195,7 @@ static SOCKET server_connect(const char *host, unsigned short nport)
 	return sock;
 }
 
-#else /* defined(SYNC_PLAYER) */
+#else
 
 void sync_set_io_cb(struct sync_device *d, struct sync_io_cb *cb)
 {
@@ -343,8 +343,8 @@ static int fetch_track_data(struct sync_device *d, struct sync_track *t)
 
 	/* send request data */
 	if (xsend(d->sock, (char *)&cmd, 1, 0) ||
-		xsend(d->sock, (char *)&name_len, sizeof(name_len), 0) ||
-		xsend(d->sock, t->name, (int)strlen(t->name), 0))
+	    xsend(d->sock, (char *)&name_len, sizeof(name_len), 0) ||
+	    xsend(d->sock, t->name, (int)strlen(t->name), 0))
 	{
 		closesocket(d->sock);
 		d->sock = INVALID_SOCKET;
@@ -365,9 +365,9 @@ static int handle_set_key_cmd(SOCKET sock, struct sync_device *data)
 	unsigned char type;
 
 	if (xrecv(sock, (char *)&track, sizeof(track), 0) ||
-		xrecv(sock, (char *)&row, sizeof(row), 0) ||
-		xrecv(sock, (char *)&v.i, sizeof(v.i), 0) ||
-		xrecv(sock, (char *)&type, 1, 0))
+	    xrecv(sock, (char *)&row, sizeof(row), 0) ||
+	    xrecv(sock, (char *)&v.i, sizeof(v.i), 0) ||
+	    xrecv(sock, (char *)&type, 1, 0))
 		return -1;
 
 	track = ntohl(track);
@@ -388,7 +388,7 @@ static int handle_del_key_cmd(SOCKET sock, struct sync_device *data)
 	uint32_t track, row;
 
 	if (xrecv(sock, (char *)&track, sizeof(track), 0) ||
-		xrecv(sock, (char *)&row, sizeof(row), 0))
+	    xrecv(sock, (char *)&row, sizeof(row), 0))
 		return -1;
 
 	track = ntohl(track);
@@ -432,7 +432,7 @@ int sync_connect(struct sync_device *d, const char *host, unsigned short port)
 }
 
 int sync_update(struct sync_device *d, int row, struct sync_cb *cb,
-	void *cb_param)
+    void *cb_param)
 {
 	if (d->sock == INVALID_SOCKET)
 		return -1;
@@ -479,7 +479,7 @@ int sync_update(struct sync_device *d, int row, struct sync_cb *cb,
 			unsigned char cmd = SET_ROW;
 			uint32_t nrow = htonl(row);
 			if (xsend(d->sock, (char*)&cmd, 1, 0) ||
-				xsend(d->sock, (char*)&nrow, sizeof(nrow), 0))
+			    xsend(d->sock, (char*)&nrow, sizeof(nrow), 0))
 				goto sockerr;
 			d->row = row;
 		}
@@ -521,7 +521,7 @@ static int create_track(struct sync_device *d, const char *name)
 }
 
 const struct sync_track *sync_get_track(struct sync_device *d,
-	const char *name)
+    const char *name)
 {
 	struct sync_track *t;
 	int idx = find_track(d, name);

--- a/lib/device.c
+++ b/lib/device.c
@@ -18,7 +18,6 @@ static int find_track(struct sync_device *d, const char *name)
 static const char *path_encode(const char *path)
 {
 	static char temp[FILENAME_MAX];
-
 	int i, pos = 0;
 	int path_len = (int)strlen(path);
 	for (i = 0; i < path_len; ++i) {
@@ -39,7 +38,6 @@ static const char *path_encode(const char *path)
 	}
 
 	temp[pos] = '\0';
-
 	return temp;
 }
 
@@ -176,7 +174,7 @@ static SOCKET server_connect(const char *host, unsigned short nport)
 			char greet[128];
 
 			if (xsend(sock, CLIENT_GREET, strlen(CLIENT_GREET), 0) ||
-			    xrecv(sock, greet, strlen(SERVER_GREET), 0)) {
+				xrecv(sock, greet, strlen(SERVER_GREET), 0)) {
 				closesocket(sock);
 				sock = INVALID_SOCKET;
 				continue;
@@ -197,7 +195,7 @@ static SOCKET server_connect(const char *host, unsigned short nport)
 	return sock;
 }
 
-#else
+#else /* defined(SYNC_PLAYER) */
 
 void sync_set_io_cb(struct sync_device *d, struct sync_io_cb *cb)
 {
@@ -207,6 +205,11 @@ void sync_set_io_cb(struct sync_device *d, struct sync_io_cb *cb)
 }
 
 #endif
+
+void sync_set_path_encode_cb(struct sync_device *d, const char *(*path_encode_cb)(const char *path))
+{
+	d->path_encode_cb = path_encode_cb;
+}
 
 #ifdef NEED_STRDUP
 static inline char *rocket_strdup(const char *str)
@@ -340,8 +343,8 @@ static int fetch_track_data(struct sync_device *d, struct sync_track *t)
 
 	/* send request data */
 	if (xsend(d->sock, (char *)&cmd, 1, 0) ||
-	    xsend(d->sock, (char *)&name_len, sizeof(name_len), 0) ||
-	    xsend(d->sock, t->name, (int)strlen(t->name), 0))
+		xsend(d->sock, (char *)&name_len, sizeof(name_len), 0) ||
+		xsend(d->sock, t->name, (int)strlen(t->name), 0))
 	{
 		closesocket(d->sock);
 		d->sock = INVALID_SOCKET;
@@ -362,9 +365,9 @@ static int handle_set_key_cmd(SOCKET sock, struct sync_device *data)
 	unsigned char type;
 
 	if (xrecv(sock, (char *)&track, sizeof(track), 0) ||
-	    xrecv(sock, (char *)&row, sizeof(row), 0) ||
-	    xrecv(sock, (char *)&v.i, sizeof(v.i), 0) ||
-	    xrecv(sock, (char *)&type, 1, 0))
+		xrecv(sock, (char *)&row, sizeof(row), 0) ||
+		xrecv(sock, (char *)&v.i, sizeof(v.i), 0) ||
+		xrecv(sock, (char *)&type, 1, 0))
 		return -1;
 
 	track = ntohl(track);
@@ -385,7 +388,7 @@ static int handle_del_key_cmd(SOCKET sock, struct sync_device *data)
 	uint32_t track, row;
 
 	if (xrecv(sock, (char *)&track, sizeof(track), 0) ||
-	    xrecv(sock, (char *)&row, sizeof(row), 0))
+		xrecv(sock, (char *)&row, sizeof(row), 0))
 		return -1;
 
 	track = ntohl(track);
@@ -429,7 +432,7 @@ int sync_connect(struct sync_device *d, const char *host, unsigned short port)
 }
 
 int sync_update(struct sync_device *d, int row, struct sync_cb *cb,
-    void *cb_param)
+	void *cb_param)
 {
 	if (d->sock == INVALID_SOCKET)
 		return -1;
@@ -476,7 +479,7 @@ int sync_update(struct sync_device *d, int row, struct sync_cb *cb,
 			unsigned char cmd = SET_ROW;
 			uint32_t nrow = htonl(row);
 			if (xsend(d->sock, (char*)&cmd, 1, 0) ||
-			    xsend(d->sock, (char*)&nrow, sizeof(nrow), 0))
+				xsend(d->sock, (char*)&nrow, sizeof(nrow), 0))
 				goto sockerr;
 			d->row = row;
 		}
@@ -518,7 +521,7 @@ static int create_track(struct sync_device *d, const char *name)
 }
 
 const struct sync_track *sync_get_track(struct sync_device *d,
-    const char *name)
+	const char *name)
 {
 	struct sync_track *t;
 	int idx = find_track(d, name);

--- a/lib/device.c
+++ b/lib/device.c
@@ -18,6 +18,11 @@ static int find_track(struct sync_device *d, const char *name)
 static const char *path_encode(const char *path)
 {
 	static char temp[FILENAME_MAX];
+
+#ifdef ALLOW_NON_PORTABLE_PATH_CHARACTERS
+	strncpy(temp, path, sizeof(temp) - 1);
+	temp[sizeof(temp) - 1] = '\0';
+#else
 	int i, pos = 0;
 	int path_len = (int)strlen(path);
 	for (i = 0; i < path_len; ++i) {
@@ -38,6 +43,8 @@ static const char *path_encode(const char *path)
 	}
 
 	temp[pos] = '\0';
+#endif
+
 	return temp;
 }
 

--- a/lib/device.h
+++ b/lib/device.h
@@ -49,6 +49,7 @@ struct sync_device {
 	SOCKET sock;
 #endif
 	struct sync_io_cb io_cb;
+    const char *(*path_encode_cb)(const char *path);
 };
 
 #endif /* SYNC_DEVICE_H */

--- a/lib/device.h
+++ b/lib/device.h
@@ -49,7 +49,7 @@ struct sync_device {
 	SOCKET sock;
 #endif
 	struct sync_io_cb io_cb;
-    const char *(*path_encode_cb)(const char *path);
+	const char *(*path_encode_cb)(const char *path);
 };
 
 #endif /* SYNC_DEVICE_H */

--- a/lib/sync.h
+++ b/lib/sync.h
@@ -25,6 +25,12 @@ struct sync_track;
 struct sync_device *sync_create_device(const char *);
 void sync_destroy_device(struct sync_device *);
 
+struct sync_io_cb {
+    void *(*open)(const char *filename, const char *mode);
+    size_t (*read)(void *ptr, size_t size, size_t nitems, void *stream);
+    int (*close)(void *stream);
+};
+
 #ifndef SYNC_PLAYER
 struct sync_cb {
 	void (*pause)(void *, int);
@@ -36,14 +42,14 @@ int sync_tcp_connect(struct sync_device *, const char *, unsigned short);
 int SYNC_DEPRECATED("use sync_tcp_connect instead") sync_connect(struct sync_device *, const char *, unsigned short);
 int sync_update(struct sync_device *, int, struct sync_cb *, void *);
 int sync_save_tracks(const struct sync_device *);
-#endif /* defined(SYNC_PLAYER) */
 
-struct sync_io_cb {
-	void *(*open)(const char *filename, const char *mode);
-	size_t (*read)(void *ptr, size_t size, size_t nitems, void *stream);
-	int (*close)(void *stream);
-};
+#else /* defined(SYNC_PLAYER) */
+
 void sync_set_io_cb(struct sync_device *d, struct sync_io_cb *cb);
+
+#endif
+
+void sync_set_path_encode_cb(struct sync_device *d, const char *(*path_encode_cb)(const char *path));
 
 const struct sync_track *sync_get_track(struct sync_device *, const char *);
 double sync_get_val(const struct sync_track *, double);

--- a/lib/sync.h
+++ b/lib/sync.h
@@ -25,12 +25,6 @@ struct sync_track;
 struct sync_device *sync_create_device(const char *);
 void sync_destroy_device(struct sync_device *);
 
-struct sync_io_cb {
-    void *(*open)(const char *filename, const char *mode);
-    size_t (*read)(void *ptr, size_t size, size_t nitems, void *stream);
-    int (*close)(void *stream);
-};
-
 #ifndef SYNC_PLAYER
 struct sync_cb {
 	void (*pause)(void *, int);
@@ -42,12 +36,14 @@ int sync_tcp_connect(struct sync_device *, const char *, unsigned short);
 int SYNC_DEPRECATED("use sync_tcp_connect instead") sync_connect(struct sync_device *, const char *, unsigned short);
 int sync_update(struct sync_device *, int, struct sync_cb *, void *);
 int sync_save_tracks(const struct sync_device *);
+#endif /* defined(SYNC_PLAYER) */
 
-#else /* defined(SYNC_PLAYER) */
-
+struct sync_io_cb {
+	void *(*open)(const char *filename, const char *mode);
+	size_t (*read)(void *ptr, size_t size, size_t nitems, void *stream);
+	int (*close)(void *stream);
+};
 void sync_set_io_cb(struct sync_device *d, struct sync_io_cb *cb);
-
-#endif
 
 void sync_set_path_encode_cb(struct sync_device *d, const char *(*path_encode_cb)(const char *path));
 


### PR DESCRIPTION
Allow a way to circumvent the 'pedantic' path/file encoding feature of GNU Rocket.

Reasons:
- In a few cases it's nice to be able to define relative or full file system path where GNU Rocket tracks are handled and located. Encoding prevents using "/" and/or "\\" in the rocket base name. So defining paths with forced encoding would need chdir call or so, which then leads to other issues and portability challenges...

- Quite many (desktop) operating systems are more flexible with naming conventions, so strict POSIX enforcing isn't nice for end users, who like to have whitespaces in path/file names, or something similar.
