### PR TITLE
Allow path separators

### DIFF
--- a/lib/device.c
+++ b/lib/device.c
@@ -17,7 +17,15 @@ static int find_track(struct sync_device *d, const char *name)
 
 static int valid_path_char(char ch)
 {
-	return isalnum(ch) || ch == '.' || ch == '_';
+	switch (ch) {
+	case '.':
+	case '_':
+	case '/':
+		return 1;
+
+	default:
+		return isalnum(ch);
+	}
 }
 
 static const char *path_encode(const char *path)

--- a/lib/device.c
+++ b/lib/device.c
@@ -236,6 +236,9 @@ struct sync_device *sync_create_device(const char *base)
 	if (!d)
 		return NULL;
 
+	if (!base || base[0] == '/')
+		return NULL;
+
 	d->base = strdup(path_encode(base));
 	if (!d->base) {
 		free(d);

--- a/lib/device.c
+++ b/lib/device.c
@@ -15,6 +15,11 @@ static int find_track(struct sync_device *d, const char *name)
 	return -1; /* not found */
 }
 
+static int valid_path_char(char ch)
+{
+	return isalnum(ch) || ch == '.' || ch == '_';
+}
+
 static const char *path_encode(const char *path)
 {
 	static char temp[FILENAME_MAX];
@@ -22,7 +27,7 @@ static const char *path_encode(const char *path)
 	int path_len = (int)strlen(path);
 	for (i = 0; i < path_len; ++i) {
 		int ch = path[i];
-		if (isalnum(ch) || ch == '.' || ch == '_') {
+		if (valid_path_char(ch)) {
 			if (pos >= sizeof(temp) - 1)
 				break;
 


### PR DESCRIPTION
@mrautio: I think this does roughly what we need to allow path-separators again, yet staying a bit safe. I left out windows-style path-separators, to keep things cross-platform. What do you think?