### PR TITLE
editor: store connection objects for some signals/slots

### DIFF
--- a/editor/mainwindow.cpp
+++ b/editor/mainwindow.cpp
@@ -553,25 +553,24 @@ void MainWindow::onTabChanged(int index)
 	Q_ASSERT(trackViews.size() == tabWidget->count());
 
 	if (currentTrackView != NULL) {
-		disconnect(currentTrackView, SIGNAL(posChanged(int, int)),
-		           this,             SLOT(onPosChanged(int, int)));
-		disconnect(currentTrackView, SIGNAL(editRowChanged(int)),
-		           this,             SLOT(onEditRowChanged(int)));
-		disconnect(currentTrackView, SIGNAL(currValDirty()),
-		           this,             SLOT(onCurrValDirty()));
-
+		disconnect(posChangedConnection);
+		disconnect(editRowChangedConnection);
+		disconnect(editRowChangedConnection);
 		currentTrackView = NULL;
 	}
 
 	if (index >= 0) {
 		currentTrackView = trackViews[index];
 
-		connect(currentTrackView, SIGNAL(posChanged(int, int)),
-		        this,             SLOT(onPosChanged(int, int)));
-		connect(currentTrackView, SIGNAL(editRowChanged(int)),
-		        this,             SLOT(onEditRowChanged(int)));
-		connect(currentTrackView, SIGNAL(currValDirty()),
-		        this,             SLOT(onCurrValDirty()));
+		posChangedConnection = connect(
+			currentTrackView, SIGNAL(posChanged(int, int)),
+			this,             SLOT(onPosChanged(int, int)));
+		editRowChangedConnection = connect(
+			currentTrackView, SIGNAL(editRowChanged(int)),
+			this,             SLOT(onEditRowChanged(int)));
+		currValDirtyConnection = connect(
+			currentTrackView, SIGNAL(currValDirty()),
+			this,             SLOT(onCurrValDirty()));
 
 		currentTrackView->setFocus();
 	}

--- a/editor/mainwindow.h
+++ b/editor/mainwindow.h
@@ -53,7 +53,10 @@ public:
 
 	QTabWidget *tabWidget;
 	QList<TrackView *> trackViews;
+
 	TrackView *currentTrackView;
+	QMetaObject::Connection posChangedConnection, editRowChangedConnection,
+	                        currValDirtyConnection;
 
 	QLabel *statusPos, *statusValue, *statusKeyType;
 	QMenu *recentFilesMenu;


### PR DESCRIPTION
The lifetime of the TrackViews is somehow complicated to keep track of,
and when we're setting the document, we end up trying to disconnect
signals from a TrackView that's currently being deleted.

This is no big deal, as all Qt does is emit a warning and move on. But
it's even nicer to avoid this warning, and we can do that in a pretty
simple way without having to change the code much; by storing the
connection object and disconnecting that instead.

So let's do that. This gets us rid of these three warnings whenever we
load a new document:

QObject::disconnect: No such signal QObject::posChanged(int, int)
QObject::disconnect: No such signal QObject::editRowChanged(int)
QObject::disconnect: No such signal QObject::currValDirty()