### PR TITLE
editor: make sure .rocket-files are stored consistently

### DIFF
--- a/editor/editor.cpp
+++ b/editor/editor.cpp
@@ -11,6 +11,10 @@ int main(int argc, char *argv[])
 
 	MainWindow mainWindow;
 
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
+	qSetGlobalQHashSeed(0);
+#endif
+
 	if (app.arguments().size() > 1) {
 		if (app.arguments().size() > 2) {
 			QMessageBox::critical(&mainWindow, NULL, QString("usage: %1 [filename.rocket]").arg(argv[0]), QMessageBox::Ok);


### PR DESCRIPTION
Since Qt 5.6, hash-tables are stored in randomized order. This leads to
visible changes in .rocket-files, because QtXml uses hash-tables to
store XML-atributes.

The long term solution would probably be to drop Qt4 support, and move
to QXmlStreamReader / QXmlStreamWriter instead, but for now we can just
fix the hash-seed.