### PR TITLE
Add interfaces for value setting and pause control from the demo side

### DIFF
--- a/lib/device.c
+++ b/lib/device.c
@@ -578,15 +578,13 @@ int sync_update(struct sync_device *d, int row, struct sync_cb *cb,
 		}
 	}
 
-	if (cb && cb->is_playing && cb->is_playing(cb_param)) {
-		if (d->row != row && d->sock != INVALID_SOCKET) {
-			unsigned char cmd = SET_ROW;
-			uint32_t nrow = htonl(row);
-			if (xsend(d->sock, (char*)&cmd, 1, 0) ||
-			    xsend(d->sock, (char*)&nrow, sizeof(nrow), 0))
-				goto sockerr;
-			d->row = row;
-		}
+	if (d->row != row && d->sock != INVALID_SOCKET) {
+		unsigned char cmd = SET_ROW;
+		uint32_t nrow = htonl(row);
+		if (xsend(d->sock, (char*)&cmd, 1, 0) ||
+		    xsend(d->sock, (char*)&nrow, sizeof(nrow), 0))
+			goto sockerr;
+		d->row = row;
 	}
 	return 0;
 

--- a/lib/device.c
+++ b/lib/device.c
@@ -427,6 +427,16 @@ static int send_set_key_cmd(const struct sync_device *d, const struct sync_track
 	return 0;
 }
 
+static int send_pause_cmd(const struct sync_device *d)
+{
+	unsigned char cmd = PAUSE;
+
+	if (xsend(d->sock, (char *)&cmd, sizeof(cmd), 0))
+		return -1;
+
+	return 0;
+}
+
 static int fetch_track_data(struct sync_device *d, struct sync_track *t)
 {
 	unsigned char cmd = GET_TRACK;
@@ -589,6 +599,11 @@ sockerr:
 int sync_set_val(const struct sync_device *d, const struct sync_track *t, int row, float val, enum key_type type)
 {
 	return send_set_key_cmd(d, t, row, val, type);
+}
+
+int sync_pause(const struct sync_device *d)
+{
+	return send_pause_cmd(d);
 }
 
 #endif /* !defined(SYNC_PLAYER) */

--- a/lib/device.c
+++ b/lib/device.c
@@ -16,7 +16,7 @@
  #include <network.h>
 #endif
 
-static int find_track(struct sync_device *d, const char *name)
+static int find_track(const struct sync_device *d, const char *name)
 {
 	int i;
 	for (i = 0; i < (int)d->num_tracks; ++i)

--- a/lib/sync.h
+++ b/lib/sync.h
@@ -50,6 +50,7 @@ void sync_set_io_cb(struct sync_device *d, struct sync_io_cb *cb);
 const struct sync_track *sync_get_track(struct sync_device *, const char *);
 double sync_get_val(const struct sync_track *, double);
 int sync_set_val(const struct sync_device *d, const struct sync_track *t, int row, float val, enum key_type type);
+int sync_pause(const struct sync_device *d);
 
 #ifdef __cplusplus
 }

--- a/lib/sync.h
+++ b/lib/sync.h
@@ -11,6 +11,8 @@ extern "C" {
 
 #include <stddef.h>
 
+#include "track.h"
+
 #ifdef __GNUC__
 #define SYNC_DEPRECATED(msg) __attribute__ ((deprecated(msg)))
 #elif defined(_MSC_VER)
@@ -47,6 +49,7 @@ void sync_set_io_cb(struct sync_device *d, struct sync_io_cb *cb);
 
 const struct sync_track *sync_get_track(struct sync_device *, const char *);
 double sync_get_val(const struct sync_track *, double);
+int sync_set_val(const struct sync_device *d, const struct sync_track *t, int row, float val, enum key_type type);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
For some things the pattern editor interface is very cumbersome, and a more interactive visual and spatial demo-side manipulation of the pattern data is preferable.

Before one can implement such an interaction model we need a way to send this information back to the editor.  These functions are a first step in that direction.