### PR TITLE
Drop Qt 4.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ cache:
 addons:
   apt:
     packages:
+      - qt5-default
       - libsdl1.2-dev
 
 before_deploy:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 Rocket is an intuitive new way of... bah, whatever. It's a sync-tracker, a
 tool for synchronizing music and visuals in demoscene productions. It
-consists of a GUI editor (using [Qt](https://www.qt.io/)), and an ANSI C
+consists of a GUI editor (using [Qt5](https://www.qt.io/)), and an ANSI C
 library that can either communicate with the editor over a network socket,
 or play back an exported data-set.
 

--- a/editor/editor.pro
+++ b/editor/editor.pro
@@ -2,13 +2,9 @@ TEMPLATE = app
 TARGET = editor
 DEPENDPATH += .
 
-QT = core gui xml network
+QT = core gui xml network widgets
 
-greaterThan(QT_MAJOR_VERSION, 4) {
-    QT += widgets
-
-    qtHaveModule(websockets): QT += websockets
-}
+qtHaveModule(websockets): QT += websockets
 
 !contains(QT, websockets): message("QWebSockets module not found, disabling websocket support...")
 


### PR DESCRIPTION
Qt 6 is planned to be released at the end of the year, and the Qt 4 support is somewhat crippled (missing websocket support). I think it's time to drop the Q4 support. This will allow us to embrace Qt 5 features more in the code-base, and should reduce the need to jump through hoops.