### PR TITLE
Updated README.md with new repo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ keyboard shortcut. Here's a list of the supported keyboard shortcuts:
   [Processing](https://processing.org/).
 * [pyrocket](https://github.com/Contraz/pyrocket), a Python 3
   implementation of the client and player.
-* [Rust Rocket](https://github.com/darksecond/rust-rocket), a Rust
+* [Rust Rocket](https://github.com/demoscene-rs/rust-rocket), a Rust
   implementation of the client and player. Crate available
   [here](https://crates.io/crates/rust-rocket).
 


### PR DESCRIPTION
The rust implementation of rocket has been moved to a new home on github, edited the README.md file to reflect this.