### PR TITLE
Fix TravisCI macOS build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,7 @@ before_script:
       brew update &&
       brew install qt5 &&
       brew install sdl &&
-      export QT5_PREFIX="`brew --prefix qt5`";
-      export QMAKE="$QT5_PREFIX/bin/qmake";
+      brew link --force qt5;
     fi
   - if [ ! -f deps/bass24.zip ]; then
         mkdir -p deps && (

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,8 @@ before_script:
       brew update &&
       brew install qt5 &&
       brew install sdl &&
-      brew link --force qt5;
+      brew link --force qt5 &&
+      export CPPFLAGS=-DGL_SILENCE_DEPRECATION;
     fi
   - if [ ! -f deps/bass24.zip ]; then
         mkdir -p deps && (

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ os:
   - linux
   - osx
 
+osx_image: xcode12.2
+
 before_script:
   - if [ "$TRAVIS_OS_NAME" = "osx" ]; then
       brew update &&


### PR DESCRIPTION
The macOS CI build was broken, primarily because brew no longer provides a bottle for SDL versions this old.

While we're at it, also simplify the CI setup a bit, so we would have seen the right problem as an error message instead.

Fixes: #82