### PR TITLE
ci: add windows build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,3 +56,21 @@ jobs:
         with:
           name: rocket-editor-macos
           path: editor/editor.app
+  build-windows:
+    name: Build (Windows)
+    runs-on: windows-2022
+    steps:
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v3
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup MSVC devenv
+        uses: ilammy/msvc-dev-cmd@v1
+      - name: Build Editor
+        run: |
+          qmake -tp vc editor/editor.pro
+          msbuild editor.vcxproj /v:minimal /property:Configuration=Release /nologo
+      - uses: actions/upload-artifact@v3
+        with:
+          name: rocket-editor-windows
+          path: release/editor.exe

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,5 +54,5 @@ jobs:
           done;
       - uses: actions/upload-artifact@v3
         with:
-          name: rocket-editor
+          name: rocket-editor-macos
           path: editor/editor.app


### PR DESCRIPTION
This only builds the editor, because we don't have VS2008 on GitHub actions.

It's probably about time to change to change to a build-system that doesn't need upgrading the project files every time we compile with a different compiler, so let's leave it at that for now.