### PR TITLE
macos: upload dmg macos artifact instead of broken app-bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,12 @@ jobs:
               install_name_tool -change $prefix/lib/$target.framework/Versions/5/$target @executable_path/../Frameworks/$target.framework/Versions/5/$target $plugin;
             done;
           done;
+      - name: Create DMG file
+        run: hdiutil create -format UDZO -srcfolder editor/editor.app editor/editor.dmg
       - uses: actions/upload-artifact@v3
         with:
           name: rocket-editor-macos
-          path: editor/editor.app
+          path: editor/editor.dmg
   build-windows:
     name: Build (Windows)
     runs-on: windows-2022


### PR DESCRIPTION
No clue if this actually works, but at least it's not missing the root directory, which is what the actual app-bundle is.