### PR TITLE
ci: cache windows-deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
     steps:
       - name: Install Qt
         uses: jurplel/install-qt-action@v3
+        with:
+          cache: true
+          tools: ''
       - name: Checkout
         uses: actions/checkout@v3
       - name: Setup MSVC devenv


### PR DESCRIPTION
Installing Qt takes an unreasonably long time on Windows, so let's enable the internal cache for this.

While we're at it, also disable installing QtCreator, which we don't use.