### PR TITLE
player: fix implicit cast warning

### DIFF
--- a/lib/device.c
+++ b/lib/device.c
@@ -25,7 +25,7 @@ static int find_track(struct sync_device *d, const char *name)
 	return -1; /* not found */
 }
 
-static int valid_path_char(char ch)
+static int valid_path_char(int ch)
 {
 	switch (ch) {
 	case '.':


### PR DESCRIPTION
There's no good reason to pass a char instead of an int here, and if we don't, we have to add a cast. Let's just pass the int all the way through.