### PR TITLE
Abstract socket communcations behind a callback interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,8 @@ endif
 
 LIB_OBJS = \
 	lib/device.o \
-	lib/track.o
+	lib/track.o \
+	lib/tcp.o
 
 all: lib/librocket.a lib/librocket-player.a editor
 

--- a/lib/device.h
+++ b/lib/device.h
@@ -66,6 +66,8 @@ struct sync_device {
 #ifndef SYNC_PLAYER
 	int row;
 	SOCKET sock;
+	struct sync_sockio_cb sockio_cb;
+	void *sockio_ctxt;
 #endif
 	struct sync_io_cb io_cb;
 };

--- a/lib/device.h
+++ b/lib/device.h
@@ -65,7 +65,6 @@ struct sync_device {
 
 #ifndef SYNC_PLAYER
 	int row;
-	SOCKET sock;
 	struct sync_sockio_cb sockio_cb;
 	void *sockio_ctxt;
 #endif

--- a/lib/librocket.vs2008.vcproj
+++ b/lib/librocket.vs2008.vcproj
@@ -527,6 +527,10 @@
 				>
 			</File>
 			<File
+				RelativePath=".\tcp.c"
+				>
+			</File>
+			<File
 				RelativePath=".\track.c"
 				>
 			</File>

--- a/lib/librocket.vs2013.vcxproj
+++ b/lib/librocket.vs2013.vcxproj
@@ -278,6 +278,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="device.c" />
+    <ClCompile Include="tcp.c" />
     <ClCompile Include="track.c" />
   </ItemGroup>
   <ItemGroup>

--- a/lib/sync.h
+++ b/lib/sync.h
@@ -36,6 +36,42 @@ int sync_tcp_connect(struct sync_device *, const char *, unsigned short);
 int SYNC_DEPRECATED("use sync_tcp_connect instead") sync_connect(struct sync_device *, const char *, unsigned short);
 int sync_update(struct sync_device *, int, struct sync_cb *, void *);
 int sync_save_tracks(const struct sync_device *);
+
+struct sync_sockio_cb {
+	/* Poll for ctxt send/recv readiness, returns:
+	 * -errno on error,
+	 * 0 on nothing ready,
+	 * 1 on something ready.
+	 *
+	 * To poll readability, res_readable must be non-NULL.
+	 * To poll writeability, res_writeable must be non-NULL.
+	 * Use both to poll for readability and/or writeability.
+	 * When something requested is ready, 1 is stored at the relevant result pointer.
+	 * On error, the res pointers are not written to.
+	 */
+	int (*poll)(void *ctxt, int *res_readable, int *res_writeable);
+
+
+	/* Send len bytes via ctxt, returns:
+	 * -errno on error,
+	 * +n_bytes-sent on success.
+	 *
+	 * May block to send all bytes, may send less than len in exceptions like signals/disconnects etc.
+	 */
+	int (*send)(void *ctxt, const void *buf, int len);
+
+	/* Receive size bytes via ctxt, returns:
+	 * -errno on error,
+	 * +n_bytes-received on success.
+	 *
+	 * May block to receive len bytes, may return less than len in exceptions like signals/disconnects etc.
+	 */
+	int (*recv)(void *ctxt, void *buf, int len);
+
+	/* Close ctxt, freeing any resources associated with it. */
+	void (*close)(void *ctxt);
+};
+int sync_set_sockio_cb(struct sync_device *d, struct sync_sockio_cb *cb, void *ctxt);
 #endif /* defined(SYNC_PLAYER) */
 
 struct sync_io_cb {

--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -1,0 +1,220 @@
+#ifndef SYNC_PLAYER
+
+#include "device.h"
+#include "sync.h"
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+struct sync_tcp {
+	SOCKET sock;
+};
+
+#ifdef USE_AMITCP
+static struct Library *socket_base = NULL;
+#endif
+
+static SOCKET server_connect(const char *host, unsigned short nport)
+{
+	SOCKET sock = INVALID_SOCKET;
+#ifdef USE_GETADDRINFO
+	struct addrinfo *addr, *curr;
+	char port[6];
+#else
+	struct hostent *he;
+	char **ap;
+#endif
+
+#ifdef WIN32
+	static int need_init = 1;
+	if (need_init) {
+		WSADATA wsa;
+		if (WSAStartup(MAKEWORD(2, 0), &wsa))
+			return INVALID_SOCKET;
+		need_init = 0;
+	}
+#elif defined(USE_AMITCP)
+	if (!socket_base) {
+		socket_base = OpenLibrary("bsdsocket.library", 4);
+		if (!socket_base)
+			return INVALID_SOCKET;
+	}
+#endif
+
+#ifdef USE_GETADDRINFO
+
+	snprintf(port, sizeof(port), "%u", nport);
+	if (getaddrinfo(host, port, 0, &addr) != 0)
+		return INVALID_SOCKET;
+
+	for (curr = addr; curr; curr = curr->ai_next) {
+		int family = curr->ai_family;
+		struct sockaddr *sa = curr->ai_addr;
+		int sa_len = (int)curr->ai_addrlen;
+
+#else
+
+	he = gethostbyname(host);
+	if (!he)
+		return INVALID_SOCKET;
+
+	for (ap = he->h_addr_list; *ap; ++ap) {
+		int family = he->h_addrtype;
+		struct sockaddr_in sin;
+		struct sockaddr *sa = (struct sockaddr *)&sin;
+		int sa_len = sizeof(*sa);
+
+		sin.sin_family = he->h_addrtype;
+		sin.sin_port = htons(nport);
+		memcpy(&sin.sin_addr, *ap, he->h_length);
+		memset(&sin.sin_zero, 0, sizeof(sin.sin_zero));
+
+#endif
+		sock = socket(family, SOCK_STREAM, 0);
+		if (sock == INVALID_SOCKET)
+			continue;
+
+		if (connect(sock, sa, sa_len) >= 0) {
+#ifdef USE_NODELAY
+			int yes = 1;
+
+			/* Try disabling Nagle since we're latency-sensitive, UDP would
+			 * really be more appropriate but that's a much bigger change.
+			 */
+			(void) setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (void *)&yes, sizeof(yes));
+#endif
+			break;
+		}
+
+		closesocket(sock);
+		sock = INVALID_SOCKET;
+	}
+
+#ifdef USE_GETADDRINFO
+	freeaddrinfo(addr);
+#endif
+
+	return sock;
+}
+
+static int sync_tcp_poll(void *ctxt, int *res_readable, int *res_writeable)
+{
+	struct sync_tcp *tcp = ctxt;
+#ifdef GEKKO
+	// libogc doesn't impmelent select()...
+	struct pollsd sds[1];
+	int events = (res_readable ? POLLIN : 0) | (res_writeable ? POLLOUT : 0)
+	sds[0].socket  = tcp->sock;
+	sds[0].events  = events;
+	sds[0].revents = 0;
+	if (net_poll(sds, 1, 0) < 0) return 0;
+	if (res_readable)
+		*res_readable = (sds[0].revents & POLLIN) && !(sds[0].revents & (POLLERR|POLLHUP|POLLNVAL));
+	if (res_writeable)
+		*res_writeable = (sds[0].revents & POLLOUT) && !(sds[0].revents & (POLLERR|POLLHUP|POLLNVAL));
+	return 1;
+#else
+	struct timeval to = { 0, 0 };
+	fd_set rfds, wfds;
+	int r;
+
+	FD_ZERO(&rfds);
+	FD_ZERO(&wfds);
+
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable: 4127)
+#endif
+	if (res_readable)
+		FD_SET(tcp->sock, &rfds);
+	if (res_writeable)
+		FD_SET(tcp->sock, &wfds);
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
+
+	r = select((int)tcp->sock + 1, &rfds, &wfds, NULL, &to);
+	if (r > 0) {
+		if (res_readable)
+			*res_readable = FD_ISSET(tcp->sock, &rfds);
+		if (res_writeable)
+			*res_writeable = FD_ISSET(tcp->sock, &wfds);
+	}
+	return r;
+
+#endif
+}
+
+static int sync_tcp_send(void *ctxt, const void *buf, int len)
+{
+	struct sync_tcp *tcp = ctxt;
+
+#ifdef WIN32
+	assert(len <= INT_MAX);
+	return send(tcp->sock, (const char *)buf, (int)len, 0);
+#else
+	return send(tcp->sock, (const char *)buf, len, 0);
+#endif
+}
+
+static int sync_tcp_recv(void *ctxt, void *buf, int len)
+{
+	struct sync_tcp *tcp = ctxt;
+
+#ifdef WIN32
+	assert(len <= INT_MAX);
+	return recv(tcp->sock, (char *)buf, (int)len, 0);
+#else
+	return recv(tcp->sock, (char *)buf, len, 0);
+#endif
+}
+
+static void sync_tcp_close(void *ctxt)
+{
+	struct sync_tcp *tcp = ctxt;
+
+	closesocket(tcp->sock);
+	free(tcp);
+}
+
+static struct sync_sockio_cb sync_tcp_sockio = {
+	.poll = sync_tcp_poll,
+	.send = sync_tcp_send,
+	.recv = sync_tcp_recv,
+	.close = sync_tcp_close,
+};
+
+int sync_tcp_connect(struct sync_device *d, const char *host, unsigned short port)
+{
+	struct sync_tcp *tcp;
+
+	tcp = malloc(sizeof(*tcp));
+	if (!tcp)
+		return -1;
+
+	tcp->sock = server_connect(host, port);
+	if (tcp->sock == INVALID_SOCKET) {
+		free(tcp);
+		return -1;
+	}
+
+	return sync_set_sockio_cb(d, &sync_tcp_sockio, tcp);
+}
+
+int sync_connect(struct sync_device *d, const char *host, unsigned short port)
+{
+	return sync_tcp_connect(d, host, port);
+}
+
+void sync_tcp_device_dtor(void)
+{
+	/* XXX: this is janky */
+#if defined(USE_AMITCP)
+	if (socket_base) {
+		CloseLibrary(socket_base);
+		socket_base = NULL;
+	}
+#endif
+}
+
+#endif /* !defined(SYNC_PLAYER) */


### PR DESCRIPTION
This series introduces an abstract socket IO mechanism for callers implementing their own communications handling.

The existing sync_tcp_connect()/sync_connect() functions are refactored to share this underlying abstraction, resulting in better separation of the network code from core Rocket protocol handling code.