### PR TITLE
player: implement sync_retire_track()

### DIFF
--- a/lib/sync.h
+++ b/lib/sync.h
@@ -82,6 +82,7 @@ struct sync_io_cb {
 void sync_set_io_cb(struct sync_device *d, struct sync_io_cb *cb);
 
 const struct sync_track *sync_get_track(struct sync_device *, const char *);
+int sync_retire_track(struct sync_device *, const struct sync_track *);
 double sync_get_val(const struct sync_track *, double);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This adds the ability to "retire" a track, which frees the track and its associated keys, sending RETIRE_TRACK to the Editor if connected so the Editor can also discard the track from its UI.

The track id is not recycled to keep things simple for now.

The impetus for this is demos having an interactive creative process that dynamically add tracks at different names as the composition evolves.  With enough iteration, there's a tendency for a large amount of unused tracks to accumulate.

This gives such interactively constructed demos a mechanism for discarding tracks from the Editor when they become unused.