### PR TITLE
player: add missing string.h include

### DIFF
--- a/lib/tcp.c
+++ b/lib/tcp.c
@@ -5,6 +5,7 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 struct sync_tcp {
 	SOCKET sock;


### PR DESCRIPTION
I missed this in moving the tcp stuff out of device.c into tcp.c. It throws a warning here when compiling without USE_GETADDRINFO:

lib/tcp.c: In function 'server_connect':
lib/tcp.c:69:17: warning: implicit declaration of function 'memcpy' [-Wimplicit-function-declaration]
   69 |                 memcpy(&sin.sin_addr, *ap, he->h_length);
      |                 ^~~~~~
lib/tcp.c:8:1: note: include '<string.h>' or provide a declaration of 'memcpy'
    7 | #include <stdlib.h>
  +++ |+#include <string.h>
    8 |
lib/tcp.c:69:17: warning: incompatible implicit declaration of built-in function 'memcpy' [-Wbuiltin-declaration-mismatch]
   69 |                 memcpy(&sin.sin_addr, *ap, he->h_length);
      |                 ^~~~~~
lib/tcp.c:69:17: note: include '<string.h>' or provide a declaration of 'memcpy'
lib/tcp.c:70:17: warning: implicit declaration of function 'memset' [-Wimplicit-function-declaration]
   70 |                 memset(&sin.sin_zero, 0, sizeof(sin.sin_zero));
      |                 ^~~~~~
lib/tcp.c:70:17: note: include '<string.h>' or provide a declaration of 'memset'
lib/tcp.c:70:17: warning: incompatible implicit declaration of built-in function 'memset' [-Wbuiltin-declaration-mismatch]
lib/tcp.c:70:17: note: include '<string.h>' or provide a declaration of 'memset'

for obvious reasons, trivial change.