### PR TITLE
player: fix potential segfault on destroy

### DIFF
--- a/lib/device.c
+++ b/lib/device.c
@@ -170,7 +170,7 @@ void sync_destroy_device(struct sync_device *d)
 	int i;
 
 #ifndef SYNC_PLAYER
-	if (!d->sockio_ctxt)
+	if (d->sockio_ctxt)
 		sockio_close(d);
 
 	sync_tcp_device_dtor();


### PR DESCRIPTION
There's a spurious ! in here inverting the logic.  The close is supposed to happen when the sockio_ctxt is set, not when NULL.

Accidentally introduced by me in fa61dcf, found using rototiller, trivial fix.